### PR TITLE
Add milestone documentation

### DIFF
--- a/MILESTONE.md
+++ b/MILESTONE.md
@@ -1,0 +1,52 @@
+# Milestone for CA--pi Project
+
+## Project Overview
+
+The CA--pi project aims to create a comprehensive platform for managing and analyzing data related to the Pi cryptocurrency. The project includes various components such as data collection, data processing, and data visualization.
+
+## Milestone Details
+
+### Milestone 1: Initial Release
+
+- **Objective**: Complete the initial release of the CA--pi platform.
+- **Tasks**:
+  - Set up the project repository.
+  - Implement data collection module.
+  - Implement data processing module.
+  - Implement data visualization module.
+  - Write documentation for the project.
+- **Deadline**: [Insert Deadline Date]
+
+### Milestone 2: Feature Enhancement
+
+- **Objective**: Enhance the platform with additional features.
+- **Tasks**:
+  - Add support for additional data sources.
+  - Improve data processing algorithms.
+  - Enhance data visualization capabilities.
+  - Update documentation with new features.
+- **Deadline**: [Insert Deadline Date]
+
+### Milestone 3: Performance Optimization
+
+- **Objective**: Optimize the performance of the platform.
+- **Tasks**:
+  - Profile the platform to identify performance bottlenecks.
+  - Optimize data collection module.
+  - Optimize data processing module.
+  - Optimize data visualization module.
+  - Update documentation with performance improvements.
+- **Deadline**: [Insert Deadline Date]
+
+## Running Workflows with GitHub Actions
+
+To run the workflows defined in this repository, you can use GitHub Actions. Here are the steps to run the workflows:
+
+1. Ensure you have a GitHub account and access to the repository.
+2. Navigate to the repository on GitHub.
+3. Go to the "Actions" tab.
+4. You will see the workflows defined in the repository, such as `CA-pi` and `Deno`.
+5. Click on the workflow you want to run.
+6. Click the "Run workflow" button to manually trigger the workflow.
+
+The workflows will run based on the triggers defined in the workflow files, such as push or pull request events on the `main` branch.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ const signInUser = (authResult: any) => {
 
   return setShowModal(false);
 };
+
+## Milestones
+
+For detailed information about the milestones for the CA--pi project, please refer to the [MILESTONE.md](MILESTONE.md) file.


### PR DESCRIPTION
Related to #8

Add milestone documentation for the CA--pi project.

* **MILESTONE.md**
  - Create a new file named `MILESTONE.md`.
  - Add detailed information about the milestones for the CA--pi project.
  - Include instructions on how to run the workflows using GitHub Actions.

* **README.md**
  - Add a link to the `MILESTONE.md` file for detailed milestone information.

Running

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mathurr016/CA--pi/pull/9?shareId=9079f45b-5894-4b5d-b432-f865a5dddcf2).